### PR TITLE
Removing last two warnings, when set to pedantic only

### DIFF
--- a/ucs2-afb/ucs_apihat.c
+++ b/ucs2-afb/ucs_apihat.c
@@ -61,7 +61,7 @@ static const struct afb_binding binding_description = {
  int afbBindingV1ServiceInit(struct afb_service service) {
    afbSrv =  service;
    return (0);
-};
+}
 
 /*
  * activation function for registering the binding called by afb-daemon

--- a/ucs2-afb/ucs_binding.c
+++ b/ucs2-afb/ucs_binding.c
@@ -67,7 +67,7 @@ static ucsContextT *ucsContextS;
 PUBLIC void UcsXml_CB_OnError(const char format[], uint16_t vargsCnt, ...) {
     //DEBUG (afbIface, format, args);
     va_list args;
-    va_start (args, format);
+    va_start (args, vargsCnt);
     vfprintf (stderr, format, args);
     va_end(args);
 }


### PR DESCRIPTION
The changes made to va_start statement could be crucial.