### PR TITLE
Implement handling of GPIO, I2C, Routes

### DIFF
--- a/ucs2-afb/ucs_binding.c
+++ b/ucs2-afb/ucs_binding.c
@@ -185,6 +185,14 @@ void UCSI_CB_OnAmsMessageReceived(void *pTag)
 	   Don't forget to call UCSI_ReleaseAmsMessage after that */
 }
 
+void UCSI_CB_OnRouteResult(void *pTag, uint16_t routeId, bool isActive)
+{
+}
+
+void UCSI_CB_OnGpioStateChange(void *pTag, uint16_t nodeAddress, uint8_t gpioPinId, bool isHighState)
+{
+}
+
 bool Cdev_Init(CdevData_t *d, const char *fileName, bool read, bool write)
 {
     if (NULL == d || NULL == fileName)  goto OnErrorExit;

--- a/ucs2-interface/ucs-xml/UcsXml.c
+++ b/ucs2-interface/ucs-xml/UcsXml.c
@@ -1158,12 +1158,11 @@ static ParseResult_t ParseScriptMsgSend(mxml_node_t *act, Ucs_Ns_Script_t *scr, 
     if (!GetUInt8(act, OP_TYPE_REQUEST, &req->OpCode, true))
         RETURN_ASSERT(Parse_XmlError);
 
-    if (!GetUInt8(act, OP_TYPE_RESPONSE, &res->OpCode, true))
-        RETURN_ASSERT(Parse_XmlError);
-
     res->FBlockId = req->FBlockId;
     res->FunktId = req->FunktId;
-    GetPayload(act, PAYLOAD_RES_HEX, &res->DataPtr, &res->DataLen, 0, &priv->objList, false);
+
+    if (GetUInt8(act, OP_TYPE_RESPONSE, &res->OpCode, false))
+        GetPayload(act, PAYLOAD_RES_HEX, &res->DataPtr, &res->DataLen, 0, &priv->objList, false);
 
     if (!GetPayload(act, PAYLOAD_REQ_HEX, &req->DataPtr, &req->DataLen, 0, &priv->objList, true))
         RETURN_ASSERT(Parse_XmlError);

--- a/ucs2-interface/ucs_config.h
+++ b/ucs2-interface/ucs_config.h
@@ -39,6 +39,7 @@
 #define DEBUG_XRM
 #define BOARD_PMS_TX_SIZE       (72)
 #define CMD_QUEUE_LEN           (6)
+#define I2C_WRITE_MAX_LEN       (32)
 
 #include <string.h>
 #include <stdarg.h>
@@ -72,7 +73,10 @@ typedef enum
     UnicensCmd_Init,
     UnicensCmd_Stop,
     UnicensCmd_RmSetRoute,
-    UnicensCmd_NsRun
+    UnicensCmd_NsRun,
+    UnicensCmd_GpioCreatePort,
+    UnicensCmd_GpioWritePort,
+    UnicensCmd_I2CWrite
 } UnicensCmd_t;
 
 /**
@@ -105,12 +109,48 @@ typedef struct
  */
 typedef struct
 {
+    uint16_t destination;
+    uint16_t debounceTime;
+} UnicensCmdGpioCreatePort_t;
+
+/**
+ * \brief Internal struct for Unicens Integration
+ */
+typedef struct
+{
+    uint16_t destination;
+    uint16_t mask;
+    uint16_t data;
+} UnicensCmdGpioWritePort_t;
+
+/**
+ * \brief Internal struct for Unicens Integration
+ */
+typedef struct
+{
+    uint16_t destination;
+    bool isBurst;
+    uint8_t blockCount;
+    uint8_t slaveAddr;
+    uint16_t timeout;
+    uint8_t dataLen;
+    uint8_t data[I2C_WRITE_MAX_LEN];
+} UnicensCmdI2CWrite_t;
+
+/**
+ * \brief Internal struct for Unicens Integration
+ */
+typedef struct
+{
     UnicensCmd_t cmd;
     union
     {
         UnicensCmdInit_t Init;
         UnicensCmdRmSetRoute_t RmSetRoute;
         UnicensCmdNsRun_t NsRun;
+        UnicensCmdGpioCreatePort_t GpioCreatePort;
+        UnicensCmdGpioWritePort_t GpioWritePort;
+        UnicensCmdI2CWrite_t I2CWrite;
     } val;
 } UnicensCmdEntry_t;
 

--- a/ucs2-interface/ucs_interface.h
+++ b/ucs2-interface/ucs_interface.h
@@ -160,12 +160,43 @@ void UCSI_ReleaseAmsMessage(UCSI_Data_t *my);
  * \note Call this function only from single context (not from ISR)
  *
  * \param pPriv - private data section of this instance
- * \param routeId - identifier as given in XML file along with MOST socket
+ * \param routeId - identifier as given in XML file along with MOST socket (unique)
  * \param isActive - true, route will become active. false, route will be deallocated
  * 
  * \return true, if route was found and the specific command was enqueued to Unicens.
  */
 bool UCSI_SetRouteActive(UCSI_Data_t *pPriv, uint16_t routeId, bool isActive);
+
+/**
+ * \brief Enables or disables a route by the given routeId
+ * \note Call this function only from single context (not from ISR)
+ *
+ * \param pPriv - private data section of this instance
+ * \param targetAddress - targetAddress - The node / group target address
+ * \param isBurst - true, write blockCount I2C telegrams dataLen with a single call. false, write a single I2C message.
+ * \param blockCount - amount of blocks to write. Only used when isBurst is set to true.
+ * \param slaveAddr - The I2C address.
+ * \param timeout - Timeout in milliseconds.
+ * \param dataLen - Amount of bytes to send via I2C
+ * \param pData - The payload to be send.
+ *
+ * \return true, if route command was enqueued to Unicens.
+ */
+bool UCSI_I2CWrite(UCSI_Data_t *pPriv, uint16_t targetAddress, bool isBurst, uint8_t blockCount,
+    uint8_t slaveAddr, uint16_t timeout, uint8_t dataLen, uint8_t *pData);
+
+/**
+ * \brief Enables or disables a route by the given routeId
+ * \note Call this function only from single context (not from ISR)
+ *
+ * \param pPriv - private data section of this instance
+ * \param targetAddress - targetAddress - The node / group target address
+ * \param gpioPinId - INIC GPIO PIN starting with 0 for the first GPIO.
+ * \param isHighState - true, high state = 3,3V. false, low state = 0V.
+ *
+ * \return true, if GPIO command was enqueued to Unicens.
+ */
+bool UCSI_SetGpioState(UCSI_Data_t *pPriv, uint16_t targetAddress, uint8_t gpioPinId, bool isHighState);
 
 /*>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>*/
 /*                        CALLBACK SECTION                              */
@@ -238,6 +269,25 @@ extern void UCSI_CB_OnStop(void *pTag);
  * \param pTag - Pointer given by the integrator by UCSI_Init
  */
 extern void UCSI_CB_OnAmsMessageReceived(void *pTag);
+
+/**
+ * \brief Callback when a route become active / inactive.
+ * \note This function must be implemented by the integrator
+ * \param pTag - Pointer given by the integrator by UCSI_Init
+ * \param routeId - identifier as given in XML file along with MOST socket (unique)
+ * \param isActive - true, if the route is now in use. false, the route is not established.
+ */
+extern void UCSI_CB_OnRouteResult(void *pTag, uint16_t routeId, bool isActive);
+
+/**
+ * \brief Callback when a INIC GPIO changes its state
+ * \note This function must be implemented by the integrator
+ * \param pTag - Pointer given by the integrator by UCSI_Init
+ * \param nodeAddress - Node Address of the INIC sending the update.
+ * \param gpioPinId - INIC GPIO PIN starting with 0 for the first GPIO.
+ * \param isHighState - true, high state = 3,3V. false, low state = 0V.
+ */
+extern void UCSI_CB_OnGpioStateChange(void *pTag, uint16_t nodeAddress, uint8_t gpioPinId, bool isHighState);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This patch improves the usage of remote I2C and GPIOs.
It delivers a callback on changed Unicens Routes.
Two minimal bug fixes related to scripting:
- be tolerant, when there is no expected response in XML script.
- only execute scripts, when device is marked as available.
